### PR TITLE
feat: add show parameter to control LTtx console output

### DIFF
--- a/LTtx/tx/tx.py
+++ b/LTtx/tx/tx.py
@@ -231,7 +231,7 @@ class txl:
     
     def sys_print(self,data,show_force=False):
         msg = '%sLTtx[info]>>>>:%s,'%(self.get_nowtime(),data)
-        if self.sys_print_on or show_force:            
+        if self.sys_print_on:            
             print(msg)
         self.save_log(msg)
 
@@ -1309,10 +1309,10 @@ class txl:
                 self.sys_print(msg)
                 break
             time.sleep(1)
-        print('退出心跳------')
+        self.sys_print('退出心跳------')
         if who in self.txg_dict and not self.txg_dict[who]['txg_running']:
             self.__connect_txg(who,pwd=pwd)
-        print('我全退出了')
+        self.sys_print('我全退出了')
     
     
     def create_channel(self,num=30):

--- a/cfquant/client.py
+++ b/cfquant/client.py
@@ -38,15 +38,18 @@ class LTtxRpcClient(object):
         self._callbacks = {}
         self._lock = threading.RLock()
         self._pending_lock = threading.RLock()
+        self._show = True
         self._started = False
         self._recv_thread = None
 
-    def start(self):
+    def start(self, show=None):
         with self._lock:
             if self._started:
                 return
+            if show is not None:
+                self._show = show
             txl = self._load_txl()
-            self._tx = txl(self.host, self.port, self.token)
+            self._tx = txl(self.host, self.port, self.token, show=self._show)
             self._tx.start_tx()
             self._tx.start_txg(self.client_id)
             self._started = True


### PR DESCRIPTION
- client.py: start() now accepts show=None to control log verbosity, default True preserves existing behavior
- tx.py: remove show_force override in sys_print(), replace raw print() with sys_print() for unified control